### PR TITLE
FIX apache 2.4 htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,10 +1,25 @@
-############################################
-## By default deny all access
-Order allow,deny
-Deny from all
-###########################################
-## Allow access to soap server file only 
-<Files soap.php>
-    order allow,deny
-    allow from all
-</Files>
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    ############################################
+    ## By default deny all access
+    Order allow,deny
+    Deny from all
+    ###########################################
+    ## Allow access to soap server file only 
+    <Files soap.php>
+        order allow,deny
+        allow from all
+    </Files>
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    ############################################
+    ## By default deny all access
+    Require all denied
+    ###########################################
+    ## Allow access to soap server file only 
+    <Files soap.php>
+        Require all granted
+    </Files>
+</IfModule>


### PR DESCRIPTION
Apache 2.4 introduces a few breaking changes, most notably in access control configuration. For more information, check the [upgrading document](http://httpd.apache.org/docs/2.4/upgrading.html)