### PR TITLE
FIX#7 - NullRef protection

### DIFF
--- a/Components/FieldsFactory.php
+++ b/Components/FieldsFactory.php
@@ -548,7 +548,7 @@ class FieldsFactory
     public function addChoices(array $fieldChoices): self
     {
         foreach ($fieldChoices as $value => $description) {
-            $this->addChoice($value, $description);
+            $this->addChoice($value, $description ?? "");
         }
 
         return $this;


### PR DESCRIPTION
Fixes an issue when connecting a system that has previously used SlashSync, but that had for some reason to move to another server and reconnect to Splash on a new account.