### PR TITLE
FIX PHP Error  with an Update of NuSOAPInterface.php

### DIFF
--- a/Components/NuSOAP/NuSOAPInterface.php
+++ b/Components/NuSOAP/NuSOAPInterface.php
@@ -107,7 +107,7 @@ class NuSOAPInterface implements CommunicationInterface
         //     Splash::log()->www("[NuSOAP] Raw Response", htmlspecialchars($this->client->response, ENT_QUOTES));
         // }
 
-        return $response;
+        return json_encode($response);
     }
 
     //====================================================================//


### PR DESCRIPTION
FIX the following type error

Uncaught Error: Splash\Components\NuSOAP\NuSOAPInterface::call(): Return value must be of type ?string, array returned in /www/ridinfamily_458/public/wp-content/plugins/splash-connector/vendor/splash/phpcore/Components/NuSOAP/NuSOAPInterface.php on line 110

Call stack:

    Splash\C\N\NuSOAPInterface::call('Ping', array)
    wp-content/plugins/splash-connector/vendor/splash/phpcore/Components/Webservice.php:310
    Splash\Components\Webservice::call('Ping', NULL, true)
    wp-content/plugins/splash-connector/vendor/splash/phpcore/Client/Splash.php:49
    Splash\Client\Splash::ping()
    wp-content/plugins/splash-connector/includes/class-splash-wordpress-settings.php:514
    Splash_Wordpress_Settings::renderInfo()
    wp-content/plugins/splash-connector/includes/class-splash-wordpress-settings.php:289
    Splash_Wordpress_Settings::settings_page('')
    wp-includes/class-wp-hook.php:324
    WP_Hook::apply_filters('', array)
    wp-includes/class-wp-hook.php:348
    WP_Hook::do_action(array)
    wp-includes/plugin.php:517
    do_action('settings_page_splash-wordpress-plugin_settings')
    wp-admin/admin.php:260
    require_once('/www/ridinfamily_458/public/wp-admin/admin.php')
    wp-admin/options-general.php:10